### PR TITLE
Add small margin between icon and label

### DIFF
--- a/src/generateScss.js
+++ b/src/generateScss.js
@@ -24,6 +24,7 @@ const iconScss = (icon, codepoint, color) => `
       color ? `color: ${color};\n    ` : ''
     }&:before {
       content: '\\${codepoint}';
+      margin-right: .25em;
     }
   }
 `;


### PR DESCRIPTION
I felt that the icon and label need some breathing room especially with Ruby icon:

![image](https://cloud.githubusercontent.com/assets/729565/17175655/08acf362-5409-11e6-972a-1403168712e3.png) ➡️ ![image](https://cloud.githubusercontent.com/assets/729565/17175638/e9d3be26-5408-11e6-8c86-211a9a97be88.png)
