### PR TITLE
Add a configuration for disabling colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ Map of process name to color string. Example:
 
 Look at [`src/mapColors.js`][7] for defaults.
 
+#### `config.tabIcons.disableColors`
+
+* Type: `boolean`
+* Default: `false`
+
+Toggles icon colors. Similar to setting all colors to `#FFF`.
+
 ### Contribution
 
 Obviously there are an almost infinite amount of processes out there, so any

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ let activeStyle = { transition: 'opacity 200ms ease-in' };
 let inactiveStyle = { color: '#fff', opacity: 0.3 };
 let mapIcons = {};
 let mapColors = {};
+let disableColors = false;
 const loadConfig = () => {
   const config = window.config.getConfig();
   if (config.tabIcons) {
@@ -17,6 +18,7 @@ const loadConfig = () => {
     if (config.tabIcons.inactiveStyle) inactiveStyle = config.tabIcons.inactiveStyle;
     if (config.tabIcons.mapIcons) mapIcons = config.tabIcons.mapIcons;
     if (config.tabIcons.mapColors) mapColors = config.tabIcons.mapColors;
+    if (config.tabIcons.disableColors) disableColors = true;
   }
 };
 
@@ -49,6 +51,8 @@ const getIcon = title => {
 
 const getCustomTitle = (title, active) => {
   const icon = getIcon(title);
+  // can we inherit color from theme/config somehow?
+  const iconColor = disableColors ? '#FFF' : mapColors[icon.name];
   return React.createElement(
     'span',
     {},
@@ -60,7 +64,7 @@ const getCustomTitle = (title, active) => {
           Object.assign(
             {},
             activeStyle,
-            mapColors[icon.name] ? { color: mapColors[icon.name] } : {}
+            iconColor ? { color: iconColor } : {}
           ) :
           inactiveStyle,
       }


### PR DESCRIPTION
A quick way to disable colors for all icons. If there's a way to inherit theme color (so we get the same as text), I'm all ears! :)
