### PR TITLE
Add color for Python

### DIFF
--- a/src/mapColors.js
+++ b/src/mapColors.js
@@ -8,4 +8,5 @@ module.exports = {
   ruby: '#CC342D',
   shell: '#FFF',
   zsh: '#C5DB00',
+  python: '#FFDF59',
 };


### PR DESCRIPTION
Taken directly from the Python logo, yellow color