### PR TITLE
Apply regex approach

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 const React = require('react');
-const { filter } = require('fuzzaldrin');
 
 const NAME = require('./package.json').name;
 
@@ -44,7 +43,9 @@ const loadIcons = () => {
 
 const getIcon = title => {
   loadIcons();
-  const results = filter(classes, title.split(' ')[0], { maxResults: 1 });
+  const results = classes.filter((e) => {
+    return new RegExp(`(?:[\\W]+|^)(${e})(?:[\\W]+|$)`, 'i').test(title);
+  });
   const match = results.length === 0 ? 'shell' : results[0];
   return { class: icons[match], name: match };
 };

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "homepage": "https://github.com/dfrankland/hyper-tab-icons#readme",
   "dependencies": {
-    "fuzzaldrin": "^2.1.0",
     "react": "^15.4.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -792,10 +792,6 @@ function-bind@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
 
-fuzzaldrin@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/fuzzaldrin/-/fuzzaldrin-2.1.0.tgz#90204c3e2fdaa6941bb28d16645d418063a90e9b"
-
 gauge@~2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.6.0.tgz#d35301ad18e96902b4751dcbbe40f4218b942a46"


### PR DESCRIPTION
I have same problem(#17).
This PR is not configurable.

I use [pure](https://github.com/sindresorhus/pure) prompt.
It shows process name at the after `—` when I adopt regex instead of [atom/fuzzaldrin](https://github.com/atom/fuzzaldrin).
I think don't need fuzzy matching.

This regex `(?:[\W]+|^)(PROCESS_NAME)(?:[\W]+|$)` match below cases.
In this case PROCESS_NAME is 'foo'.

- 'user : ~/work/github foo'
- 'user : foo - ~/work/github'
- 'foo : user - ~/work/github'

```javascript
> const regex = /(?:[\W]+|^)(foo)(?:[\W]+|$)/
> regex.test('user : ~/work/github foo');
true
> regex.test('user : foo - ~/work/github');
true
> regex.test('foo : user - ~/work/github');
true
```

![pr](https://cloud.githubusercontent.com/assets/1206676/21953471/bac93c60-da7b-11e6-8d3d-3e9064893026.gif)

Please close this PR If you don't need.
