### PR TITLE
Added support for lumo ClojureScript interpreter

### DIFF
--- a/src/mapIcons.js
+++ b/src/mapIcons.js
@@ -11,6 +11,7 @@ module.exports = {
   clojure: [
     'lein',
     'planck',
+    'lumo',
   ],
   docker: [
     'docker-compose',


### PR DESCRIPTION
[lumo](https://github.com/anmonteiro/lumo) is another ClojureScript REPL that I forgot to add.